### PR TITLE
Allow emoji to be optional

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -34,19 +34,20 @@ By default the release notes will contain the following sections:
 |===
 |Title |Label Text
 
-|New Features
+|":star: New Features"
 |"enhancement"
 
-|Bug Fixes
+|":beetle: Bug Fixes"
 |"regression" or "bug"
 
-|Documentation
+|":notebook_with_decorative_cover: Documentation"
 |"documentation"
 
-|Dependency Upgrades
+|":hammer: Dependency Upgrades"
 |"dependency-upgrade"
 |===
 
+The title is in https://guides.github.com/features/mastering-markdown[Markdown] format and emoji like ":star:" can be used.
 If you want something different then you can add `sections` YAML:
 
 [source,yaml]
@@ -54,10 +55,8 @@ If you want something different then you can add `sections` YAML:
 releasenotes:
   sections:
   - title: "Enhancements"
-    emoji: ":star:"
     labels: ["new"]
   - title: "Bugs"
-    emoji: ":beetle:"
     labels: ["fix"]
 ----
 

--- a/src/main/java/io/spring/releasenotes/generator/ReleaseNotesSection.java
+++ b/src/main/java/io/spring/releasenotes/generator/ReleaseNotesSection.java
@@ -24,7 +24,6 @@ import io.spring.releasenotes.github.payload.Label;
 
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
-import org.springframework.util.StringUtils;
 
 /**
  * A single section of a change log report.
@@ -35,19 +34,16 @@ class ReleaseNotesSection {
 
 	private final String title;
 
-	private final String emoji;
-
 	private final List<String> labels;
 
-	ReleaseNotesSection(String title, String emoji, String... labels) {
-		this(title, emoji, Arrays.asList(labels));
+	ReleaseNotesSection(String title, String... labels) {
+		this(title, Arrays.asList(labels));
 	}
 
-	ReleaseNotesSection(String title, String emoji, List<String> labels) {
+	ReleaseNotesSection(String title, List<String> labels) {
 		Assert.hasText(title, "Title must not be empty");
 		Assert.isTrue(!CollectionUtils.isEmpty(labels), "Labels must not be empty");
 		this.title = title;
-		this.emoji = emoji;
 		this.labels = labels;
 	}
 
@@ -64,12 +60,7 @@ class ReleaseNotesSection {
 
 	@Override
 	public String toString() {
-		if (StringUtils.hasText(this.emoji)) {
-			return this.emoji + " " + this.title;
-		}
-		else {
-			return this.title;
-		}
+		return this.title;
 	}
 
 }

--- a/src/main/java/io/spring/releasenotes/generator/ReleaseNotesSection.java
+++ b/src/main/java/io/spring/releasenotes/generator/ReleaseNotesSection.java
@@ -24,6 +24,7 @@ import io.spring.releasenotes.github.payload.Label;
 
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * A single section of a change log report.
@@ -44,7 +45,6 @@ class ReleaseNotesSection {
 
 	ReleaseNotesSection(String title, String emoji, List<String> labels) {
 		Assert.hasText(title, "Title must not be empty");
-		Assert.hasText(emoji, "Emoji must not be empty");
 		Assert.isTrue(!CollectionUtils.isEmpty(labels), "Labels must not be empty");
 		this.title = title;
 		this.emoji = emoji;
@@ -64,7 +64,12 @@ class ReleaseNotesSection {
 
 	@Override
 	public String toString() {
-		return this.emoji + " " + this.title;
+		if (StringUtils.hasText(this.emoji)) {
+			return this.emoji + " " + this.title;
+		}
+		else {
+			return this.title;
+		}
 	}
 
 }

--- a/src/main/java/io/spring/releasenotes/generator/ReleaseNotesSections.java
+++ b/src/main/java/io/spring/releasenotes/generator/ReleaseNotesSections.java
@@ -41,15 +41,15 @@ class ReleaseNotesSections {
 	private static final List<ReleaseNotesSection> DEFAULT_SECTIONS;
 	static {
 		List<ReleaseNotesSection> sections = new ArrayList<>();
-		add(sections, "New Features", ":star:", "enhancement");
-		add(sections, "Bug Fixes", ":beetle:", "bug", "regression");
-		add(sections, "Documentation", ":notebook_with_decorative_cover:", "documentation");
-		add(sections, "Dependency Upgrades", ":hammer:", "dependency-upgrade");
+		add(sections, ":star: New Features", "enhancement");
+		add(sections, ":beetle: Bug Fixes", "bug", "regression");
+		add(sections, ":notebook_with_decorative_cover: Documentation", "documentation");
+		add(sections, ":hammer: Dependency Upgrades", "dependency-upgrade");
 		DEFAULT_SECTIONS = Collections.unmodifiableList(sections);
 	}
 
-	private static void add(List<ReleaseNotesSection> sections, String title, String emoji, String... labels) {
-		sections.add(new ReleaseNotesSection(title, emoji, labels));
+	private static void add(List<ReleaseNotesSection> sections, String title, String... labels) {
+		sections.add(new ReleaseNotesSection(title, labels));
 	}
 
 	private final List<ReleaseNotesSection> sections;
@@ -66,8 +66,7 @@ class ReleaseNotesSections {
 	}
 
 	private ReleaseNotesSection adapt(Section propertySection) {
-		return new ReleaseNotesSection(propertySection.getTitle(), propertySection.getEmoji(),
-				propertySection.getLabels());
+		return new ReleaseNotesSection(propertySection.getTitle(), propertySection.getLabels());
 	}
 
 	public Map<ReleaseNotesSection, List<Issue>> collate(List<Issue> issues) {

--- a/src/main/java/io/spring/releasenotes/properties/ApplicationProperties.java
+++ b/src/main/java/io/spring/releasenotes/properties/ApplicationProperties.java
@@ -113,7 +113,8 @@ public class ApplicationProperties {
 	public static class Section {
 
 		/**
-		 * The title of the section in Markdown format. Can also contain emoji characters like ":star:".
+		 * The title of the section in Markdown format. Can also contain emoji characters
+		 * like ":star:".
 		 */
 		private String title;
 

--- a/src/main/java/io/spring/releasenotes/properties/ApplicationProperties.java
+++ b/src/main/java/io/spring/releasenotes/properties/ApplicationProperties.java
@@ -113,14 +113,9 @@ public class ApplicationProperties {
 	public static class Section {
 
 		/**
-		 * The title of the section.
+		 * The title of the section in Markdown format. Can also contain emoji characters like ":star:".
 		 */
 		private String title;
-
-		/**
-		 * The emoji character to use, for example ":star:".
-		 */
-		private String emoji;
 
 		/**
 		 * The labels used to identify if an issue is for the section.
@@ -133,14 +128,6 @@ public class ApplicationProperties {
 
 		public void setTitle(String title) {
 			this.title = title;
-		}
-
-		public String getEmoji() {
-			return this.emoji;
-		}
-
-		public void setEmoji(String emoji) {
-			this.emoji = emoji;
 		}
 
 		public List<String> getLabels() {

--- a/src/test/java/io/spring/releasenotes/properties/ApplicationPropertiesTests.java
+++ b/src/test/java/io/spring/releasenotes/properties/ApplicationPropertiesTests.java
@@ -50,9 +50,11 @@ public class ApplicationPropertiesTests {
 		assertThat(github.getOrganization()).isEqualTo("testorg");
 		assertThat(github.getRepository()).isEqualTo("testrepo");
 		List<Section> sections = properties.getSections();
-		assertThat(sections.get(0).getTitle()).isEqualTo("New Features");
-		assertThat(sections.get(0).getEmoji()).isEqualTo(":star:");
+		assertThat(sections).hasSize(2);
+		assertThat(sections.get(0).getTitle()).isEqualTo(":star: New Features");
 		assertThat(sections.get(0).getLabels()).containsExactly("enhancement");
+		assertThat(sections.get(1).getTitle()).isEqualTo("Bugs");
+		assertThat(sections.get(1).getLabels()).containsExactly("bug");
 	}
 
 }

--- a/src/test/resources/io/spring/releasenotes/properties/test-application.yml
+++ b/src/test/resources/io/spring/releasenotes/properties/test-application.yml
@@ -5,6 +5,7 @@ releasenotes:
     organization: testorg
     repository: testrepo
   sections:
-  - title: "New Features"
-    emoji: ":star:"
+  - title: ":star: New Features"
     labels: ["enhancement"]
+  - title: "Bugs"
+    labels: ["bug"]


### PR DESCRIPTION
Emoji icon in release sections would be nice if it was optional in case people wanted a cleaner look and feel for their release notes (like myself).

I've ran `./mvnw verify` and previously signed the CLA