### PR TITLE
Add option to ignore issues with certain labels

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -63,6 +63,16 @@ releasenotes:
     labels: ["fix"]
 ----
 
+=== Filtering issues
+
+Issues and pull requests can be excluded from the release notes by configuring it to ignore certain labels:
+
+[source,yaml]
+----
+releasenotes:
+  ignoredLabels: ["wontfix", "question", "duplicate", "invalid"]
+----
+
 == License
 This project is Open Source software released under the
 https://www.apache.org/licenses/LICENSE-2.0.html[Apache 2.0 license].

--- a/src/main/java/io/spring/releasenotes/properties/ApplicationProperties.java
+++ b/src/main/java/io/spring/releasenotes/properties/ApplicationProperties.java
@@ -17,7 +17,9 @@
 package io.spring.releasenotes.properties;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -40,8 +42,18 @@ public class ApplicationProperties {
 	 */
 	private List<Section> sections = new ArrayList<>();
 
+	private Set<String> ignoredLabels = new HashSet<>();
+
 	public Github getGithub() {
 		return this.github;
+	}
+
+	public Set<String> getIgnoredLabels() {
+		return this.ignoredLabels;
+	}
+
+	public void setIgnoredLabels(Set<String> ignoredLabels) {
+		this.ignoredLabels = ignoredLabels;
 	}
 
 	public List<Section> getSections() {

--- a/src/test/resources/io/spring/releasenotes/generator/output-with-ignored-labels
+++ b/src/test/resources/io/spring/releasenotes/generator/output-with-ignored-labels
@@ -1,0 +1,13 @@
+## :star: New Features
+
+- PR 3 [#3](pr-3-url)
+
+## :beetle: Bug Fixes
+
+- Bug 1 [#1](bug-1-url)
+
+## :heart: Contributors
+
+We'd like to thank all the contributors who worked on this release!
+
+- [@contributor1](contributor1-github-url)


### PR DESCRIPTION
Add the ability to ignore issues or PRs with certain labels. This is useful in case a bug or enhancement is initially targeted to a milestone but is later closed as wontfix and the milestone isn't removed. Or if you don't want certain issues to show up even if they are in the milestone like chore tasks, questions, etc.