### PR TITLE
Allow closed milestone to be selected

### DIFF
--- a/src/main/java/io/spring/githubchangeloggenerator/github/service/GitHubService.java
+++ b/src/main/java/io/spring/githubchangeloggenerator/github/service/GitHubService.java
@@ -45,7 +45,7 @@ public class GitHubService {
 
 	private static final Pattern LINK_PATTERN = Pattern.compile("<(.+)>; rel=\"(.+)\"");
 
-	private static final String MILESTONES_URI = "/repos/{owner}/{name}/milestones";
+	private static final String MILESTONES_URI = "/repos/{owner}/{name}/milestones?state=all&sort=due_on&direction=desc&per_page=50";
 
 	private static final String ISSUES_URI = "/repos/{owner}/{name}/issues?milestone={milestone}&state=closed";
 
@@ -70,7 +70,7 @@ public class GitHubService {
 				return milestone.getNumber();
 			}
 		}
-		throw new IllegalStateException("Unable to find open milestone with title '" + milestoneTitle + "'");
+		throw new IllegalStateException("Unable to find milestone with title '" + milestoneTitle + "'");
 	}
 
 	public List<Issue> getIssuesForMilestone(int milestoneNumber, Repository repository) {

--- a/src/test/java/io/spring/githubchangeloggenerator/github/service/GitHubServiceTests.java
+++ b/src/test/java/io/spring/githubchangeloggenerator/github/service/GitHubServiceTests.java
@@ -50,7 +50,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 @MockBean(GitHubProperties.class)
 public class GitHubServiceTests {
 
-	private static final String MILESTONES_URL = "/repos/org/repo/milestones";
+	private static final String MILESTONES_URL = "/repos/org/repo/milestones?state=all&sort=due_on&direction=desc&per_page=50";
 
 	private static final String ISSUES_URL = "/repos/org/repo/issues?milestone=";
 


### PR DESCRIPTION
Currently the generator will fail if the requested milestone is closed.
With this change open and closed milestones are queried, sorted by
the latest date in descending order to make it likely that recent
milestones appear in the first page of results.