### PR TITLE
Prefix the external links section with an additional newline for consistency

### DIFF
--- a/src/main/java/io/spring/githubchangeloggenerator/ChangelogGenerator.java
+++ b/src/main/java/io/spring/githubchangeloggenerator/ChangelogGenerator.java
@@ -210,7 +210,7 @@ public class ChangelogGenerator {
 	}
 
 	private void addExternalLinksContent(StringBuilder content, List<ExternalLink> externalLinks) {
-		content.append(String.format("## "));
+		content.append(String.format("%n## "));
 		content.append(String.format("External Links%n%n"));
 		externalLinks.stream().map(this::formatExternalLinks).forEach(content::append);
 	}

--- a/src/test/resources/io/spring/githubchangeloggenerator/output-with-multiple-external-link
+++ b/src/test/resources/io/spring/githubchangeloggenerator/output-with-multiple-external-link
@@ -1,3 +1,4 @@
+
 ## External Links
 
 - [Release Notes Link 1](url1)

--- a/src/test/resources/io/spring/githubchangeloggenerator/output-with-one-external-link
+++ b/src/test/resources/io/spring/githubchangeloggenerator/output-with-one-external-link
@@ -1,3 +1,4 @@
+
 ## External Links
 
 - [Release Notes Link 1](url1)


### PR DESCRIPTION
Follow up to #55 to prefix the external links section with a new line, to be consistent with the other sections